### PR TITLE
Nested filter object bug

### DIFF
--- a/src/core/urlBuilder.js
+++ b/src/core/urlBuilder.js
@@ -54,7 +54,7 @@ function createOperatorObject(memo, keys, value) {
     }
     case 3: {
       const [relationship, ...rest] = keys;
-      filter[relationship] = createOperatorObject({}, rest, value);
+      filter[relationship] = Object.assign({}, filter[relationship] || {}, createOperatorObject({}, rest, value));
       break;
     }
     default:
@@ -122,7 +122,7 @@ function parseQueryString(url) {
 * Parse a url and returns it's filters, includes, and pagination params
 * @param {string} url A url to parse
 * @example
-* unbuild("http://api.lonelyplanet.com/foo?bar=1"); // { base: "http://api.lonelyplanet.com", resource: "foo" ... } 
+* unbuild("http://api.lonelyplanet.com/foo?bar=1"); // { base: "http://api.lonelyplanet.com", resource: "foo" ... }
 */
 function unbuild(url) {
   const { base, resource } = getBaseParams(url);
@@ -282,7 +282,6 @@ function build({
   let url = `${base}${parsed}`;
 
   const params = unbuild(`${base}${resource}`);
-
   const merged = _.merge({}, {
     include: params.includes,
     page: params.page,

--- a/src/core/urlBuilder.js
+++ b/src/core/urlBuilder.js
@@ -1,8 +1,9 @@
 import merge from "lodash/merge";
 import map from "lodash/map";
+import mapKeys from "lodash/mapKeys";
 import camelCase from "lodash/camelCase";
 
-const _ = { merge, map, camelCase };
+const _ = { merge, map, mapKeys, camelCase };
 
 /**
  * Take a cacmelCaseString and return camel_case_string;
@@ -252,6 +253,15 @@ function buildQuery({ includes = [], filters = {}, page, perPage, sort, }) {
 }
 
 /**
+ * Take an object and convert all of its keys to camelCase;
+ * @param  {object} obj An object of filters
+ * @return {object} An object with camelCased keys
+ */
+function formatFilterKeys(filterObject) {
+  return _.mapKeys(filterObject, (value, key) => _.camelCase(key));
+}
+
+/**
  * Builds a url for fetching resources
  * @param  {object} options={} - Options for this request
  * @param  {string} options.base="" - The base url for the API
@@ -282,6 +292,10 @@ function build({
   let url = `${base}${parsed}`;
 
   const params = unbuild(`${base}${resource}`);
+
+  // incoming filters need to be formated the same way as
+  // when being unbuilt from the url string
+  filters = formatFilterKeys(filters);
   const merged = _.merge({}, {
     include: params.includes,
     page: params.page,

--- a/test/urlBuilder.spec.js
+++ b/test/urlBuilder.spec.js
@@ -214,6 +214,20 @@ describe("urlBuilder", () => {
     expect(filterString).to.equal("http://api.lonelyplanet.com/partner-activities?filter[partner_activity][place][equals]=362079&filter[partner_activity][duration][to]=4320&filter[partner_activity][price][between]=385,1000");
   });
 
+  it("should merge unbuilt url and filter object without creating duplicates", () => {
+    const filterString = build({
+      base: "http://api.lonelyplanet.com",
+      resource:'/partner-activities?filter[partner_activity][duration][to]=4320&filter[partner_activity][place][equals]=362079&filter[partner_activity][price][between]=385,1000&page[limit]=10&page[offset]=10',
+      filters: {
+        partner_activity: {
+          duration: { operator: 'to', value: 4320 },
+          price: { operator: 'between', value: '385,1000' } },
+        }
+    });
+
+    expect(filterString).to.equal("http://api.lonelyplanet.com/partner-activities?filter[partner_activity][duration][to]=4320&filter[partner_activity][place][equals]=362079&filter[partner_activity][price][between]=385,1000&page[limit]=10&page[offset]=10");
+  });
+
   it("should unbuild the query string with a nested filter object", () => {
     const filterString = {
       base: "http://api.lonelyplanet.com",

--- a/test/urlBuilder.spec.js
+++ b/test/urlBuilder.spec.js
@@ -199,4 +199,50 @@ describe("urlBuilder", () => {
 
     expect(params.filters.place).to.equal("361858");
   });
+
+  it("should merge url and filter object with price filter", () => {
+    const filterString = build({
+      base: "http://api.lonelyplanet.com",
+      resource: '/partner-activities?filter[partner_activity][place][equals]=362079',
+      filters: {
+        partner_activity: {
+        duration: { operator: 'to', value: 4320 },
+        price: { operator: 'between', value: '385,1000' } },
+      }
+    });
+
+    expect(filterString).to.equal("http://api.lonelyplanet.com/partner-activities?filter[partner_activity][place][equals]=362079&filter[partner_activity][duration][to]=4320&filter[partner_activity][price][between]=385,1000");
+  });
+
+  it("should unbuild the query string with a nested filter object", () => {
+    const filterString = {
+      base: "http://api.lonelyplanet.com",
+      resource:'/partner-activities?filter[partner_activity][duration][to]=4320&filter[partner_activity][place][equals]=362079&filter[partner_activity][price][between]=385,1000&page[limit]=10&page[offset]=10',
+      filters: {
+        partner_activity: {
+          duration: { operator: 'to', value: 4320 },
+          price: { operator: 'between', value: '385,1000' } },
+        }
+    };
+
+    const params = unbuild(`${filterString.base}${filterString.resource}`);
+
+    let expectedFilters = {
+      "partnerActivity": {
+        "duration": {
+          "operator": "to",
+          "value": "4320",
+        },
+        "place": "362079",
+        "price": {
+          "operator": "between",
+          "value": "385,1000",
+        }
+      }
+    };
+
+    expect(params.filters).to.deep.equal(expectedFilters);
+  });
+
+
 });


### PR DESCRIPTION
There was an issue from a dotcom-pois when building the endpoint for activities. The placeId was not being applied to the final URL that is built in the jsonapi-js library when a new poi list was lazy loaded in. This made it so activities from other locations were returning from the ajax call. 
Reference https://github.com/lonelyplanet/dotcom-pois/issues/1136. 

There are 2 issues occurring. 

1. When there are multiple filters in url string with 3 parameters ([personal_activity][price][between]) they were overwriting each other. 

To fix this I kept building up the object with all the keys

2. If a filter was in both the filter object and the the query string, keys like personal_activity were being duplicated in the final output. This was because when we parse the query string to format the filter object, the keys are formated in camelCase. When we try to merge the original filter object and the object we create from the query string the keys did not match so we had double the results in the final url. 

To fix this I formatted the filter object that was passed in to be the same as the filter object we built from the query string
