### PR TITLE
Return null model if response is corrupted

### DIFF
--- a/src/core/resource.js
+++ b/src/core/resource.js
@@ -67,6 +67,11 @@ export default class Resource {
     const run = _.memoize(createResourceFromDocument);
     const resource = run(document);
 
+    /* Handle very weird responses like that: http://stable.web.op-api-gateway.qa.lonelyplanet.com/places/363014/narratives/planning/if-you-like */
+    if (!resource) {
+      return null;
+    }
+
     return Array.isArray(resource) ?
       resource.map(r => r.toJs()) :
       resource.toJs();

--- a/test/fixtures/emptyNarrative.json
+++ b/test/fixtures/emptyNarrative.json
@@ -1,0 +1,6 @@
+{
+    "data": null,
+    "links": {
+        "self": "/places/363014/narratives/planning/if-you-like?expanded_children=true"
+    }
+}

--- a/test/resource.spec.js
+++ b/test/resource.spec.js
@@ -5,6 +5,7 @@ import placeDoc from "./fixtures/place.json";
 import placeWithImages from "./fixtures/placeWithImages.json"
 import pois from "./fixtures/pois.json";
 import poi from "./fixtures/poi.json";
+import emptyNarrative from "./fixtures/emptyNarrative.json"
 // import Benchmark from "benchmark";
 
 describe("Resource", function() {
@@ -87,6 +88,11 @@ describe("Resource", function() {
     expect(model.containingPlace.ancestry.length).to.equal(6);
     expect(model.containingPlace.activities.length).to.equal(10);
     expect(model.containingPlace.activities[0].id).to.equal("g-NUFY");
+  });
+
+  it("should return null on empty resource", () => {
+    const model = Resource.from(emptyNarrative);
+    expect(model).to.equal(null);
   });
 
   it("should add one to many relationships as instance properties", () => {


### PR DESCRIPTION
Handle responses like that: http://stable.web.op-api-gateway.qa.lonelyplanet.com/places/363014/narratives/planning/if-you-like