### PR TITLE
Remove conditional that checks for page in urlBuilder

### DIFF
--- a/src/core/urlBuilder.js
+++ b/src/core/urlBuilder.js
@@ -251,7 +251,9 @@ function buildQuery({ includes = [], filters = {}, page, perPage, sort, expanded
     urlParts.push(createFilters(filters));
   }
 
-  urlParts.push(paginate({ page, perPage }));
+  if (page || perPage) {
+    urlParts.push(paginate({ page, perPage }));
+  }
 
   if (sort) {
     urlParts.push(`sort=${sort}`)

--- a/src/core/urlBuilder.js
+++ b/src/core/urlBuilder.js
@@ -251,9 +251,7 @@ function buildQuery({ includes = [], filters = {}, page, perPage, sort, expanded
     urlParts.push(createFilters(filters));
   }
 
-  if (page) {
-    urlParts.push(paginate({ page, perPage }));
-  }
+  urlParts.push(paginate({ page, perPage }));
 
   if (sort) {
     urlParts.push(`sort=${sort}`)


### PR DESCRIPTION
This requires that `page` is passed along with `perPage`, but this
breaks the infinite scroll implementation in dotcom-pois.

It’s redundant because of the default parameter on the `paginate`
function.